### PR TITLE
Fix - update to Net::AMQP::RabbitMQ 0.31, where delivery_tag is UInt64

### DIFF
--- a/lib/Crixa.pm
+++ b/lib/Crixa.pm
@@ -11,7 +11,7 @@ our $VERSION = '0.12';
 use Moose;
 
 use Crixa::Channel;
-use Net::AMQP::RabbitMQ 0.009000;
+use Net::AMQP::RabbitMQ 0.310000;
 
 with qw(Crixa::HasMQ);
 

--- a/lib/Crixa/Message.pm
+++ b/lib/Crixa/Message.pm
@@ -8,6 +8,8 @@ our $VERSION = '0.12';
 
 use Moose;
 
+use Math::UInt64;
+
 has channel => (
     isa      => 'Crixa::Channel',
     is       => 'ro',
@@ -70,7 +72,7 @@ has exchange => (
 
 has delivery_tag => (
     is       => 'ro',
-    isa      => 'Str',
+    isa      => 'Math::UInt64',
     required => 1,
 );
 


### PR DESCRIPTION
From Net::AMQP::RabbitMQ Changes:

0.100000 - 2015-03-09
    - Support for 64-bit delivery tags via Math::Int64 (manchicken)

But Crixa stores delivery tags as strings in the queue message, and as int (for easy inc/dec/reset) in the queue mock.

Changed:

* Queue message delivery tag is UInt64 not string
* Mock queue sends out delivery tags as UInt64 not int
