### PR TITLE
Allow non-Math::UInt64 delivery tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  * Crixa now allows the message delivery_tag to be any non-negative integer
+    type as long as that type stringifies correctly.
+
+
 0.12 2015-04-22
 
   [BUG FIXES]

--- a/lib/Crixa/Message.pm
+++ b/lib/Crixa/Message.pm
@@ -9,6 +9,7 @@ our $VERSION = '0.13';
 use Moose;
 
 use Math::Int64 0.34;
+use Moose::Util::TypeConstraints;
 
 has channel => (
     isa      => 'Crixa::Channel',
@@ -70,9 +71,20 @@ has exchange => (
     required => 1,
 );
 
+# This allows both standard integers and integer objects (e.g., Math::UInt64)
+# as long as they stringify correctly.
+my $non_negative_int = subtype(
+    as 'Defined',
+    where {},
+    inline_as {
+        $_[0]->parent()->_inline_check( $_[1] )
+            . " && $_[1]  =~ /^[0-9]+\\z/ ";
+    }
+);
+
 has delivery_tag => (
     is       => 'ro',
-    isa      => 'Math::UInt64',
+    isa      => $non_negative_int,
     required => 1,
 );
 


### PR DESCRIPTION
The previous release changed the constraint on delivery_tag so
that a Math::UInt64 is always required. However,
Net::AMQP::RabbitMQ will pass a normal Perl scalar integer to
this module if the Perl install supports 64-bit unsigned
integers. This causes Crixa to throw an exception. This change
makes Crixa accept anything that looks like a positive integer.